### PR TITLE
fix: allow updating of tags from upstream

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
 
         git remote add upstream $UPSTREAM;
 
-        git fetch --tags upstream ${{ inputs.branch }} $DEPTH;
+        git fetch --tags -f upstream ${{ inputs.branch }} $DEPTH;
 
         # Removed since this is set in tradeshift/actions-git/configure-from-gpg-key@v1
         # git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com";


### PR DESCRIPTION
Some repos put marker tags like v2, and overrides them when new minor releases are made, we need to support this.