### PR TITLE
fix: force pushing tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,6 @@ runs:
         git rebase upstream/${{ inputs.branch }};
 
         if [ "${{ inputs.push }}" = "true" -a "$(git status | grep diverged)" ]; then
-            git push --tags origin $(git branch --show-current) --force-with-lease;
+            git push -f --tags origin $(git branch --show-current) --force-with-lease;
         fi;
       shell: bash


### PR DESCRIPTION
Motivation: Some repos put marker tags like v2, and overrides them when new minor releases are made, we need to support this.

The last PR only fixed pulling, but not pushing: https://github.com/Tradeshift/rebase-upstream-action/pull/4