### PR TITLE
chore: change of ownership from developer-productivity to sre

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -12,5 +12,5 @@ metadata:
     - fork
 spec:
   type: library
-  owner: developer-productivity
+  owner: sre
   lifecycle: production


### PR DESCRIPTION
This PR changes the ownership of this repo to SRE, as the developer productivity team doesn't exist anymore.